### PR TITLE
Escaping_@: Escaping @ char between templates

### DIFF
--- a/access/su.pdb
+++ b/access/su.pdb
@@ -52,7 +52,7 @@
           <value name="usracct.type">login</value>
           <value name="usracct.sessionid">$PID</value>
           <value name="usracct.application">$PROGRAM</value>
-          <value name="usracct.device">${temp.su_username}@${temp.su_tty}</value>
+          <value name="usracct.device">${temp.su_username}@@${temp.su_tty}</value>
           <value name="secevt.verdict">REJECT</value>
         </values>
         <tags>

--- a/access/sudo.pdb
+++ b/access/sudo.pdb
@@ -34,7 +34,7 @@
           <value name="usracct.type">login</value>
           <value name="usracct.sessionid">$PID</value>
           <value name="usracct.application">$PROGRAM</value>
-          <value name="usracct.device">${temp.sudo_username}@${temp.sudo_tty}</value>
+          <value name="usracct.device">${temp.sudo_username}@@${temp.sudo_tty}</value>
           <value name="usracct.object">${temp.sudo_pwd}$$ ${temp.sudo_command}</value>
           <value name="secevt.verdict">ACCEPT</value>
         </values>
@@ -63,7 +63,7 @@
           <value name="usracct.type">login</value>
           <value name="usracct.sessionid">$PID</value>
           <value name="usracct.application">$PROGRAM</value>
-          <value name="usracct.device">${temp.sudo_username}@${temp.sudo_tty}</value>
+          <value name="usracct.device">${temp.sudo_username}@@${temp.sudo_tty}</value>
           <value name="secevt.verdict">REJECT</value>
         </values>
         <tags>
@@ -90,7 +90,7 @@
           <value name="usracct.type">login</value>
           <value name="usracct.sessionid">$PID</value>
           <value name="usracct.application">$PROGRAM</value>
-          <value name="usracct.device">${temp.sudo_username}@unknown</value>
+          <value name="usracct.device">${temp.sudo_username}@@unknown</value>
           <value name="secevt.verdict">REJECT</value>
         </values>
         <tags>


### PR DESCRIPTION
  * without this syslog-ng will display the
following warning message:

Non-numeric correlation state ID found, assuming
 a literal '@' character. To avoid confusion
when using a literal '@' after a macro or
template function, write '@@' in the template.;
Template='${temp.su_username}@${temp.su_tty}’

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>